### PR TITLE
Remove require on golangci-lint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/golangci/go-tools v0.0.0-20180902103155-93eecd106a0b // indirect
 	github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d // indirect
 	github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98 // indirect
-	github.com/golangci/golangci-lint v1.13.1 // indirect
 	github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219 // indirect
 	github.com/golangci/revgrep v0.0.0-20180812185044-276a5c0a1039 // indirect
 	github.com/kr/pty v1.1.3 // indirect


### PR DESCRIPTION
It's only run by test scripts, not Go tests.

This will still fail to build on Go 1.13 due to a checksum mismatch for the go-ole module.